### PR TITLE
Exposing underlying error

### DIFF
--- a/Sources/APIClient/Response.swift
+++ b/Sources/APIClient/Response.swift
@@ -37,7 +37,7 @@ extension APIClientError: LocalizedError {
     }
     
     public var errorDescription: String? {
-        self.localizedError?.errorDescription ?? (underlyingError as? LocalizedError)?.localizedDescription
+        self.localizedError?.errorDescription ?? (underlyingError as? LocalizedError)?.errorDescription
     }
     public var failureReason: String? {
         self.localizedError?.failureReason ?? (underlyingError as? LocalizedError)?.failureReason

--- a/Sources/APIClient/Response.swift
+++ b/Sources/APIClient/Response.swift
@@ -27,10 +27,27 @@ extension APIClientError: LocalizedError {
         }
     }
     
-    public var errorDescription: String? { self.localizedError?.errorDescription }
-    public var failureReason: String? { self.localizedError?.failureReason }
-    public var recoverySuggestion: String? { self.localizedError?.recoverySuggestion }
-    public var helpAnchor: String? { self.localizedError?.helpAnchor }
+    public var underlyingError: Error {
+        switch self {
+        case .responseError(_, meta: _, underlyingError: let error),
+                .unexpectedResponseError(data: _, meta: _, underlyingError: let error),
+                .otherError(let error):
+            return error
+        }
+    }
+    
+    public var errorDescription: String? {
+        self.localizedError?.errorDescription ?? (underlyingError as? LocalizedError)?.localizedDescription
+    }
+    public var failureReason: String? {
+        self.localizedError?.failureReason ?? (underlyingError as? LocalizedError)?.failureReason
+    }
+    public var recoverySuggestion: String? {
+        self.localizedError?.recoverySuggestion ?? (underlyingError as? LocalizedError)?.recoverySuggestion
+    }
+    public var helpAnchor: String? {
+        self.localizedError?.helpAnchor ?? (underlyingError as? LocalizedError)?.helpAnchor
+    }
 }
 
 public struct Response<Response: Decodable> {


### PR DESCRIPTION
- Added underlyingError property to `APIClientError`
- Using its `LocalizedError` implementation if available and not implemented by `ResponseError`